### PR TITLE
adding more log statements

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,8 @@ const chains: ChainImplementation[] = []
 
 const { FLY_APP_NAME, ETH_CHAIN_ID, ETH_CHAIN_RPC, PORT, PROXY_PORT } = process.env
 
+console.log(`[canvas-hub-daemon] Starting canvas-hub daemon, FLY_APP_NAME=${FLY_APP_NAME}, PORT=${PORT}, PROXY_PORT=${PROXY_PORT}`)
+
 if (ETH_CHAIN_ID && ETH_CHAIN_RPC) {
   const provider = new ethers.providers.JsonRpcProvider(ETH_CHAIN_RPC)
   chains.push(new EthereumChainImplementation(ETH_CHAIN_ID, provider))
@@ -29,7 +31,10 @@ const daemon = new Daemon(chains, {
 })
 
 daemon.listen(PORT ? parseInt(PORT) : 8000)
-controller.signal.addEventListener("abort", () => daemon.close())
+controller.signal.addEventListener("abort", () => {
+  console.log("[canvas-hub-daemon] Received abort signal, closing daemon")
+  daemon.close()
+})
 
 // start the websocket proxy server
 if (FLY_APP_NAME !== undefined && PROXY_PORT !== undefined) {
@@ -46,6 +51,7 @@ if (FLY_APP_NAME !== undefined && PROXY_PORT !== undefined) {
 
     proxyReq.end()
     proxyReq.on("upgrade", (proxyRes, resSocket, head) => {
+      console.log(`[canvas-hub-daemon] proxyReq upgrade message on port ${originPort}, statusCode=${proxyRes.statusCode}`)
       if (proxyRes.statusCode) {
         reqSocket.write("HTTP/1.1 101 Web Socket Protocol Handshake\r\n")
         proxyRes.rawHeaders.forEach(
@@ -58,11 +64,16 @@ if (FLY_APP_NAME !== undefined && PROXY_PORT !== undefined) {
         reqSocket.end()
       }
     })
+    proxyReq.on("error", (e) => {
+      console.log(`[canvas-hub-daemon] error thrown by proxyReq:`)
+      console.log(e)
+    })
   })
 
   server.listen(parseInt(PROXY_PORT), () => console.log(`[canvas-hub-daemon] Proxy server listening on http://localhost:${PROXY_PORT}`))
 
   controller.signal.addEventListener("abort", () => {
+    console.log("[canvas-hub-daemon] Received abort signal, closing server")
     server.close()
     server.closeAllConnections()
   })
@@ -70,6 +81,7 @@ if (FLY_APP_NAME !== undefined && PROXY_PORT !== undefined) {
 
 let stopping = false
 process.on("SIGINT", () => {
+  console.log("Process received SIGINT message")
   if (stopping) {
     process.exit(1)
   } else {


### PR DESCRIPTION
The `canvas-hub-daemon` deployment on fly.io has been breaking mysteriously, this PR adds some code to log more things.

The one change in this PR that *does* change some behaviour is where I have added an error handler to the `proxyReq` object